### PR TITLE
Call emergency sync during die() and panic()

### DIFF
--- a/arch/arm64/kernel/traps.c
+++ b/arch/arm64/kernel/traps.c
@@ -322,6 +322,10 @@ void die(const char *str, struct pt_regs *regs, int err)
 	unsigned long flags = oops_begin();
 	int ret;
 
+	/* Try to do emergency sync with 2 secs timeout */
+	if (!in_atomic())
+		emergency_sync_wait(2000);
+
 	if (!user_mode(regs))
 		bug_type = report_bug(regs->pc, regs);
 	if (bug_type != BUG_TRAP_TYPE_NONE && !strlen(str))

--- a/include/linux/fs.h
+++ b/include/linux/fs.h
@@ -2627,6 +2627,7 @@ static inline ssize_t generic_write_sync(struct kiocb *iocb, ssize_t count)
 }
 
 extern void emergency_sync(void);
+extern void emergency_sync_wait(unsigned long timeout);
 extern void emergency_remount(void);
 #ifdef CONFIG_BLOCK
 extern sector_t bmap(struct inode *, sector_t);

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -142,6 +142,10 @@ void panic(const char *fmt, ...)
 
 	trace_kernel_panic(0);
 
+	/* Try to do emergency sync with 2 secs timeout */
+	if (!in_atomic())
+		emergency_sync_wait(2000);
+
 	/*
 	 * Disable local interrupts. This will prevent panic_smp_self_stop
 	 * from deadlocking the first cpu that invokes the panic, since


### PR DESCRIPTION
This functionality was re-implemented from Xiaomi kernel sources for SDM710 based devices.